### PR TITLE
Change the name of the fields for the SleepLogsAverage class

### DIFF
--- a/src/main/kotlin/com/noom/interview/fullstack/sleep/entity/SleepLogsAverages.kt
+++ b/src/main/kotlin/com/noom/interview/fullstack/sleep/entity/SleepLogsAverages.kt
@@ -7,7 +7,7 @@ data class SleepLogsAverages(
     val startDate: LocalDate,
     val endDate: LocalDate,
     val averageMinutesSlept: Double,
-    val averageStartedSleep: LocalTime,
-    val averageWokeUp: LocalTime,
-    val frequencyFeltWhenWokeUp: Map<Feeling, Int>,
+    val averageStartedSleepAt: LocalTime,
+    val averageWokeUpAt: LocalTime,
+    val frequencyMorningFeeling: Map<Feeling, Int>,
 )

--- a/src/main/kotlin/com/noom/interview/fullstack/sleep/rest/mapper/SleepLogMapper.kt
+++ b/src/main/kotlin/com/noom/interview/fullstack/sleep/rest/mapper/SleepLogMapper.kt
@@ -39,7 +39,7 @@ fun sleepLogsAveragesToSleepLogsAveragesDto(sleepLogsAverages: SleepLogsAverages
         startDate = sleepLogsAverages.startDate.format(DateTimeFormatter.ofPattern(DATE_FORMAT)),
         endDate = sleepLogsAverages.endDate.format(DateTimeFormatter.ofPattern(DATE_FORMAT)),
         averageMinutesSlept = sleepLogsAverages.averageMinutesSlept,
-        averageStartedSleepAt = sleepLogsAverages.averageStartedSleep.format(DateTimeFormatter.ofPattern(TIME_FORMAT)),
-        averageWokeUpAt = sleepLogsAverages.averageWokeUp.format(DateTimeFormatter.ofPattern(TIME_FORMAT)),
-        frequencyMorningFeeling = sleepLogsAverages.frequencyFeltWhenWokeUp.mapKeys { it.key.name }
+        averageStartedSleepAt = sleepLogsAverages.averageStartedSleepAt.format(DateTimeFormatter.ofPattern(TIME_FORMAT)),
+        averageWokeUpAt = sleepLogsAverages.averageWokeUpAt.format(DateTimeFormatter.ofPattern(TIME_FORMAT)),
+        frequencyMorningFeeling = sleepLogsAverages.frequencyMorningFeeling.mapKeys { it.key.name }
     )

--- a/src/main/kotlin/com/noom/interview/fullstack/sleep/service/SleepLogService.kt
+++ b/src/main/kotlin/com/noom/interview/fullstack/sleep/service/SleepLogService.kt
@@ -33,9 +33,9 @@ class SleepLogService(
             startDate = startDate,
             endDate = endDate,
             averageMinutesSlept = sleepLogs.map { Duration.between(it.startedSleepAt, it.wokeUpAt).toMinutes() }.average(),
-            averageStartedSleep = sleepLogs.map { it.startedSleepAt.toLocalTime() }.average(),
-            averageWokeUp = sleepLogs.map { it.wokeUpAt.toLocalTime() }.average(),
-            frequencyFeltWhenWokeUp = sleepLogs.groupBy { it.morningFeeling }.mapValues { it.value.size }
+            averageStartedSleepAt = sleepLogs.map { it.startedSleepAt.toLocalTime() }.average(),
+            averageWokeUpAt = sleepLogs.map { it.wokeUpAt.toLocalTime() }.average(),
+            frequencyMorningFeeling = sleepLogs.groupBy { it.morningFeeling }.mapValues { it.value.size }
         )
     }
 

--- a/src/test/kotlin/com/noom/interview/fullstack/sleep/SleepLogTestUtils.kt
+++ b/src/test/kotlin/com/noom/interview/fullstack/sleep/SleepLogTestUtils.kt
@@ -27,8 +27,8 @@ fun getSleepLogsAverages(
         startDate = startDate,
         endDate = endDate,
         averageMinutesSlept = 500.0,
-        averageStartedSleep = LocalTime.of(22, 50),
-        averageWokeUp = LocalTime.of(7, 10),
-        frequencyFeltWhenWokeUp = mapOf(Feeling.GOOD to frequency, Feeling.OK to frequency, Feeling.BAD to frequency)
+        averageStartedSleepAt = LocalTime.of(22, 50),
+        averageWokeUpAt = LocalTime.of(7, 10),
+        frequencyMorningFeeling = mapOf(Feeling.GOOD to frequency, Feeling.OK to frequency, Feeling.BAD to frequency)
     )
 }


### PR DESCRIPTION
Change the name of the fields for the SleepLogsAverage class to be more consistent with the fields of the SleepLog class