### PR TITLE
Sleep log already exists validation

### DIFF
--- a/src/main/kotlin/com/noom/interview/fullstack/sleep/exception/SleepLogAlreadyExistsException.kt
+++ b/src/main/kotlin/com/noom/interview/fullstack/sleep/exception/SleepLogAlreadyExistsException.kt
@@ -1,0 +1,5 @@
+package com.noom.interview.fullstack.sleep.exception
+
+class SleepLogAlreadyExistsException : RuntimeException() {
+    override val message: String = "Sleep log already exists for this date"
+}

--- a/src/main/kotlin/com/noom/interview/fullstack/sleep/repository/SleepLogJdbcRepository.kt
+++ b/src/main/kotlin/com/noom/interview/fullstack/sleep/repository/SleepLogJdbcRepository.kt
@@ -15,7 +15,7 @@ class SleepLogJdbcRepository(
     override fun save(sleepLog: SleepLog) {
         jdbcTemplate.update(
             "insert into sleep_log(username, log_date, started_sleep_at, woke_up_at, morning_feeling)  " +
-                    "values (:username, :date, :startedSleepAt, :wokeUpAt, :morningFeeling)",
+                    "values (:username, :logDate, :startedSleepAt, :wokeUpAt, :morningFeeling::feeling)",
             MapSqlParameterSource()
                 .addValue("username", sleepLog.username)
                 .addValue("logDate", sleepLog.logDate)
@@ -25,13 +25,13 @@ class SleepLogJdbcRepository(
         )
     }
 
-    override fun findByUsernameAndDate(username: String, date: LocalDate): SleepLog? =
+    override fun findByUsernameAndDate(username: String, logDate: LocalDate): SleepLog? =
         try {
             jdbcTemplate.queryForObject(
-                "select * from sleep_log where username = :username and log_date = :date limit 1",
+                "select * from sleep_log where username = :username and log_date = :logDate limit 1",
                 MapSqlParameterSource()
                     .addValue("username", username)
-                    .addValue("logDate", date),
+                    .addValue("logDate", logDate),
                 SleepLogRowMapper(),
             )
         } catch (e: EmptyResultDataAccessException) { null }

--- a/src/main/kotlin/com/noom/interview/fullstack/sleep/rest/controller/ControllerExceptionHandler.kt
+++ b/src/main/kotlin/com/noom/interview/fullstack/sleep/rest/controller/ControllerExceptionHandler.kt
@@ -1,6 +1,7 @@
 package com.noom.interview.fullstack.sleep.rest.controller
 
 import com.noom.interview.fullstack.sleep.exception.FieldValueInvalidException
+import com.noom.interview.fullstack.sleep.exception.SleepLogAlreadyExistsException
 import com.noom.interview.fullstack.sleep.exception.SleepLogNotFoundException
 import com.noom.interview.fullstack.sleep.rest.dto.ErrorResponseDto
 import io.swagger.v3.oas.annotations.media.Content
@@ -31,6 +32,14 @@ class ControllerExceptionHandler {
     ])
     fun handleCreateSleepLogException(e: FieldValueInvalidException) =
         ErrorResponseDto(e.message ?: "Unknown error")
+
+    @ExceptionHandler(SleepLogAlreadyExistsException::class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ApiResponse(responseCode = "400", description = "Bad Request", content = [
+        Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponseDto::class))
+    ])
+    fun handleSleepLogAlreadyExistsException(e: SleepLogAlreadyExistsException) =
+        ErrorResponseDto(e.message)
 
     @ExceptionHandler(SleepLogNotFoundException::class)
     @ResponseStatus(HttpStatus.NOT_FOUND)

--- a/src/main/kotlin/com/noom/interview/fullstack/sleep/service/SleepLogService.kt
+++ b/src/main/kotlin/com/noom/interview/fullstack/sleep/service/SleepLogService.kt
@@ -2,6 +2,7 @@ package com.noom.interview.fullstack.sleep.service
 
 import com.noom.interview.fullstack.sleep.entity.SleepLog
 import com.noom.interview.fullstack.sleep.entity.SleepLogsAverages
+import com.noom.interview.fullstack.sleep.exception.SleepLogAlreadyExistsException
 import com.noom.interview.fullstack.sleep.exception.SleepLogNotFoundException
 import com.noom.interview.fullstack.sleep.repository.SleepLogRepository
 import org.springframework.stereotype.Service
@@ -15,6 +16,10 @@ class SleepLogService(
 ) {
 
     fun createSleepLog(sleepLog: SleepLog) {
+        sleepLogRepository.findByUsernameAndDate(sleepLog.username, sleepLog.logDate)?.let {
+            throw SleepLogAlreadyExistsException()
+        }
+
         sleepLogRepository.save(sleepLog)
     }
 

--- a/src/main/resources/db/migration/V1.1__create_sleep_log_table.sql
+++ b/src/main/resources/db/migration/V1.1__create_sleep_log_table.sql
@@ -1,4 +1,4 @@
-create type feeling as enum ('good', 'bad', 'ok');
+create type feeling as enum ('GOOD', 'BAD', 'OK');
 
 create table if not exists sleep_log (
     id int generated always as identity primary key,

--- a/src/main/resources/db/migration/V1.2__create_sleep_log_username_date_unique_constraint.sql
+++ b/src/main/resources/db/migration/V1.2__create_sleep_log_username_date_unique_constraint.sql
@@ -1,0 +1,1 @@
+alter table sleep_log add constraint unique_username_date unique (username, log_date);

--- a/src/test/kotlin/com/noom/interview/fullstack/sleep/rest/controller/SleepLogControllerTest.kt
+++ b/src/test/kotlin/com/noom/interview/fullstack/sleep/rest/controller/SleepLogControllerTest.kt
@@ -1,6 +1,7 @@
 package com.noom.interview.fullstack.sleep.rest.controller
 
 import com.ninjasquad.springmockk.MockkBean
+import com.noom.interview.fullstack.sleep.exception.SleepLogAlreadyExistsException
 import com.noom.interview.fullstack.sleep.exception.SleepLogNotFoundException
 import com.noom.interview.fullstack.sleep.getSleepLog
 import com.noom.interview.fullstack.sleep.getSleepLogsAverages
@@ -42,6 +43,24 @@ class SleepLogControllerTest {
             .contentType(MediaType.APPLICATION_JSON)
             .content(json))
             .andExpect(MockMvcResultMatchers.status().isCreated)
+    }
+
+    @Test
+    fun `should return 400 when a sleep log for this username and date already exists`() {
+        val json = """{ 
+            |   "startedSleepAt": "2024-09-21 23:00", 
+            |   "wokeUpAt": "2024-09-22 07:00", 
+            |   "morningFeeling": "GOOD" 
+            |}""".trimMargin()
+        val sleepLog = getSleepLog()
+
+        every { sleepLogService.createSleepLog(sleepLog) } throws SleepLogAlreadyExistsException()
+
+        mvc.perform(MockMvcRequestBuilders.post("/sleep-log")
+            .header("username", "john")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(json))
+            .andExpect(MockMvcResultMatchers.status().isBadRequest)
     }
 
     @Test

--- a/src/test/kotlin/com/noom/interview/fullstack/sleep/service/SleepLogServiceTest.kt
+++ b/src/test/kotlin/com/noom/interview/fullstack/sleep/service/SleepLogServiceTest.kt
@@ -1,6 +1,7 @@
 package com.noom.interview.fullstack.sleep.service
 
 import com.noom.interview.fullstack.sleep.entity.Feeling
+import com.noom.interview.fullstack.sleep.exception.SleepLogAlreadyExistsException
 import com.noom.interview.fullstack.sleep.exception.SleepLogNotFoundException
 import com.noom.interview.fullstack.sleep.getSleepLog
 import com.noom.interview.fullstack.sleep.getSleepLogsAverages
@@ -31,10 +32,21 @@ class SleepLogServiceTest {
     fun `should return the saved id when the sleep log is saved`() {
         val sleepLog = getSleepLog()
 
+        every { sleepLogRepository.findByUsernameAndDate(sleepLog.username, sleepLog.logDate) } returns null
         every { sleepLogRepository.save(sleepLog) } just Runs
 
         sleepLogService.createSleepLog(sleepLog)
         verify { sleepLogRepository.save(sleepLog) }
+    }
+
+    @Test
+    fun `should throw error when a sleep log for the same username and date exists`() {
+        val sleepLog = getSleepLog()
+
+        every { sleepLogRepository.findByUsernameAndDate(sleepLog.username, sleepLog.logDate) } returns sleepLog
+        every { sleepLogRepository.save(sleepLog) } just Runs
+
+        assertThrows(SleepLogAlreadyExistsException::class.java) { sleepLogService.createSleepLog(sleepLog) }
     }
 
     @Test


### PR DESCRIPTION
Add a validation to not allow the creating of a sleep log when an entry with the same username and date already exists. This will allow only one sleep log per user/day.